### PR TITLE
improve build size

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,11 +4,11 @@ import '@carbonplan/components/fonts.css'
 import '@carbonplan/components/globals.css'
 import '@carbonplan/maps/mapbox.css'
 import theme from '@carbonplan/theme'
-import { LiveCode, Pre } from '@carbonplan/prism'
+import { Code, Pre } from '@carbonplan/prism'
 import Blockquote from '../components/blockquote'
 
 const components = {
-  code: LiveCode,
+  code: Code,
   pre: Pre,
   blockquote: Blockquote,
 }

--- a/posts/maps-library-release.md
+++ b/posts/maps-library-release.md
@@ -53,7 +53,7 @@ We've released an open-source library called [`@carbonplan/maps`](https://github
 
 For the simplest possible example, the following code renders a 2D map of global temperature with a coastline.
 
-```js
+```jsx
 import { Map, Raster, Line } from '@carbonplan/maps'
 import { useColormap } from '@carbonplan/colormaps'
 
@@ -98,7 +98,7 @@ The source data is a Zarr group with temperature data from [WorldClim](https://w
 
 With the same component, we can just as easily render a 4D map where the third dimension is the month and the fourth dimension is temperature or precipitation (labeled “band”). Pointing to this dataset, the `Raster` component becomes the following.
 
-```js
+```jsx
   <Raster
   colormap={colormap}
   clim={clim}
@@ -114,7 +114,7 @@ Here, the `selector` prop allows us to index into the full multi-dimensional arr
 
 In more advanced settings, we might want more control over rendering, including the ability to combine data across multiple layers with math. We've exposed a custom fragment shader prop `frag` to make this easy. In the sample below, we render the average temperature over January and February by loading both months at once and calculating the average on the GPU, followed by a rescaling and colormap lookup. While this requires writing [shader code](<https://www.khronos.org/opengl/wiki/Core_Language_(GLSL)>), it lets us combine data layers via arbitrarily complex math, with high performance and full control over what gets rendered. Here’s a `Raster` component that demos this approach.
 
-```js
+```jsx
 <Raster
   colormap={colormap}
   clim={[-20, 30]}


### PR DESCRIPTION
As a temporary fix to address https://github.com/carbonplan/blog/issues/72 this simply replaces the `LiveCode` component (which was not used) with `Code`, and it cuts build sizes for most pages in half or more.

Before:
```
├ ○ /404                                   238 B           296 kB
├ ○ /blog                                  2.86 kB         298 kB
├ ○ /blog/climate-financial-risks          8.33 kB         304 kB
├ ○ /blog/climate-trace-release            18.7 kB         360 kB
├ ○ /blog/compliance-users-release         3.13 kB         299 kB
├ ○ /blog/first-post-welcome               2.57 kB         298 kB
├ ○ /blog/fsoc-open-data                   4.54 kB         300 kB
├ ○ /blog/maps-library-release             369 kB          710 kB
├ λ /blog/rss.xml                          256 B           280 kB
├ ○ /blog/soil-protocols-added             7.19 kB         303 kB
├ ○ /blog/stripe-2021-additions            4.07 kB         300 kB
├ ○ /blog/usda-csaf-comment                3.32 kB         299 kB
```

After:
```
├ ○ /404                                   236 B           135 kB
├ ○ /blog                                  2.85 kB         138 kB
├ ○ /blog/climate-financial-risks          8.32 kB         143 kB
├ ○ /blog/climate-trace-release            18.6 kB         206 kB
├ ○ /blog/compliance-users-release         3.12 kB         138 kB
├ ○ /blog/first-post-welcome               2.56 kB         138 kB
├ ○ /blog/fsoc-open-data                   4.53 kB         140 kB
├ ○ /blog/maps-library-release             369 kB          556 kB
├ λ /blog/rss.xml                          254 B           116 kB
├ ○ /blog/soil-protocols-added             7.17 kB         142 kB
├ ○ /blog/stripe-2021-additions            4.06 kB         139 kB
├ ○ /blog/usda-csaf-comment                3.31 kB         138 kB
```

We can consider other more involved fixes (as discussed in the issue) later, but we can do this now without losing any functionality.