### PR TITLE
tweak title rendering

### DIFF
--- a/components/entry.js
+++ b/components/entry.js
@@ -65,10 +65,37 @@ const Entry = ({ final, first, info }) => {
               <Button
                 size='md'
                 href={articleHref}
-                suffix={<RotatingArrow />}
-                sx={{ fontFamily: 'heading' }}
+                sx={{
+                  fontFamily: 'heading',
+                  '&:hover .rotate': {
+                    color: 'secondary',
+                    transform: 'rotate(45deg)',
+                  },
+                }}
               >
-                {title}
+                {title
+                  .split(' ')
+                  .slice(0, title.split(' ').length - 1)
+                  .join(' ')}{' '}
+                <Box as='span' sx={{ whiteSpace: 'nowrap' }}>
+                  {title
+                    .split(' ')
+                    .slice(
+                      title.split(' ').length - 1,
+                      title.split(' ').length
+                    )}
+                  <RotatingArrow
+                    className='rotate'
+                    sx={{
+                      height: [18, 18, 18, 24],
+                      width: [18, 18, 18, 24],
+                      ml: ['8px', '8px', '8px', '8px'],
+                      strokeWidth: [2, 2, 2, 3],
+                      verticalAlign: 'middle',
+                      transition: 'color 0.05s, transform 0.15s',
+                    }}
+                  />
+                </Box>
               </Button>
             </Column>
           </Row>

--- a/contents.js
+++ b/contents.js
@@ -13,7 +13,7 @@ const contents = [
   {
     id: 'compliance-users-release',
     version: '1.0.0',
-    title: 'Who is using which offsets in California? ',
+    title: 'Who is using which offsets in California?',
     authors: ['Freya Chay', 'Jeremy Freeman', 'Danny Cullenward'],
     date: '01-05-2022',
     summary:

--- a/posts/compliance-users-release.md
+++ b/posts/compliance-users-release.md
@@ -1,6 +1,6 @@
 export const meta = {
   version: '1.0.0',
-  title: 'Who is using which offsets in California? ',
+  title: 'Who is using which offsets in California?',
   authors: ['Freya Chay', 'Jeremy Freeman', 'Danny Cullenward'],
   date: '01-05-2022',
   summary:


### PR DESCRIPTION
Small improvement to title rendering affecting fairly rare combinations of screen widths and article title lengths. 

Turns this:
<img width="752" alt="CleanShot 2022-02-07 at 17 32 20@2x" src="https://user-images.githubusercontent.com/3387500/152901010-c92834a2-ada6-4dea-8684-4e9ef4d7ad7c.png">

Into:
<img width="770" alt="CleanShot 2022-02-07 at 17 32 23@2x" src="https://user-images.githubusercontent.com/3387500/152901021-a1a65d60-2913-4ef8-a8bf-6058ad4abec2.png">

We've now done this twice (other place is on the press page), and while this handling is unlikely to be appropriate or necessary for general buttons, it might be worth making a special "link + rotating arrow" component that does it. Definitely don't want to reinvent this a third time!
