### PR TITLE
Dynamic year filter

### DIFF
--- a/components/list.js
+++ b/components/list.js
@@ -2,10 +2,10 @@ import { useMemo } from 'react'
 import { Box } from 'theme-ui'
 import Entry from './entry'
 
-const List = ({ posts, year }) => {
+const List = ({ posts, years }) => {
   const filteredContents = useMemo(() => {
-    return posts.filter((d) => year[d.date.split('-')[2]])
-  }, [posts, year])
+    return posts.filter((d) => years[d.date.split('-')[2]])
+  }, [posts, years])
 
   return (
     <Box>

--- a/components/main.js
+++ b/components/main.js
@@ -10,12 +10,7 @@ import {
 
 import List from './list'
 
-const currentYear = new Date().getFullYear()
-const initYears = {}
-
-for (let year = 2021; year <= currentYear; year++) {
-  initYears[year] = true
-}
+const getCurrentYear = () => new Date().getFullYear()
 
 const Settings = ({ setYears, years }) => {
   return (
@@ -31,7 +26,14 @@ const Settings = ({ setYears, years }) => {
 }
 
 const Main = ({ showMobileSettings, posts }) => {
-  const [years, setYears] = useState(initYears)
+  const [years, setYears] = useState(() => {
+    const currentYear = getCurrentYear()
+    const initYears = {}
+    for (let year = 2021; year <= currentYear; year++) {
+      initYears[year] = true
+    }
+    return initYears
+  })
 
   const settings = <Settings setYears={setYears} years={years} />
 

--- a/components/main.js
+++ b/components/main.js
@@ -11,18 +11,18 @@ import {
 import List from './list'
 
 const currentYear = new Date().getFullYear()
-const initYear = {}
+const initYears = {}
 
 for (let year = 2021; year <= currentYear; year++) {
-  initYear[year] = true
+  initYears[year] = true
 }
 
-const Settings = ({ setYear, year }) => {
+const Settings = ({ setYears, years }) => {
   return (
     <Group spacing='md'>
       <Filter
-        values={year}
-        setValues={setYear}
+        values={years}
+        setValues={setYears}
         label='Filter by year'
         showAll
       />
@@ -31,9 +31,9 @@ const Settings = ({ setYear, year }) => {
 }
 
 const Main = ({ showMobileSettings, posts }) => {
-  const [year, setYear] = useState(initYear)
+  const [years, setYears] = useState(initYears)
 
-  const settings = <Settings setYear={setYear} year={year} />
+  const settings = <Settings setYears={setYears} years={years} />
 
   return (
     <>
@@ -62,7 +62,7 @@ const Main = ({ showMobileSettings, posts }) => {
           {settings}
         </Column>
         <Column start={[1, 2, 5, 5]} width={[6, 6, 7, 7]}>
-          <List year={year} posts={posts} />
+          <List years={years} posts={posts} />
         </Column>
       </Row>
     </>

--- a/components/main.js
+++ b/components/main.js
@@ -10,10 +10,11 @@ import {
 
 import List from './list'
 
-const initYear = {
-  2021: true,
-  2022: true,
-  2023: true,
+const currentYear = new Date().getFullYear()
+const initYear = {}
+
+for (let year = 2021; year <= currentYear; year++) {
+  initYear[year] = true
 }
 
 const Settings = ({ setYear, year }) => {


### PR DESCRIPTION
The year list is dynamic now!

I made things more complicated tho -- I changed the variable names to use `years` plural for what feels like more clarity, but I may not be conceptualizing things correctly cause I see the singular naming on the press page for the format variable...
```
const initFormat = {
  print: true,
  audio: true,
  video: true,
}
```
https://github.com/carbonplan/carbonplan.org/blob/7827a44a218dd8ce01caf8de1986edd3d4272baa/pages/press.js#L105-L109

Any reason to lean one way or the other on this?

Not a huge thing obviously, just curious! 

cc @katamartin 