### PR TITLE
update charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@carbonplan/charts": "^3.0.0",
+        "@carbonplan/charts": "^3.1.1",
         "@carbonplan/colormaps": "^4.0.0",
         "@carbonplan/components": "^12.5.0",
         "@carbonplan/icons": "^2.0.0",
@@ -364,8 +364,9 @@
       }
     },
     "node_modules/@carbonplan/charts": {
-      "version": "3.0.0",
-      "license": "MIT",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@carbonplan/charts/-/charts-3.1.1.tgz",
+      "integrity": "sha512-/B/1EdQ43dWmSvRmOnFpOUqJXlM61EH1u0b3ixJzuonyaMokN1oDfkV1NpPQF2ZJkhW1NwUEBwTY/X2BKUs7rg==",
       "dependencies": {
         "d3-scale": "^3.3.0",
         "d3-shape": "^2.1.0"
@@ -9535,7 +9536,9 @@
       }
     },
     "@carbonplan/charts": {
-      "version": "3.0.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@carbonplan/charts/-/charts-3.1.1.tgz",
+      "integrity": "sha512-/B/1EdQ43dWmSvRmOnFpOUqJXlM61EH1u0b3ixJzuonyaMokN1oDfkV1NpPQF2ZJkhW1NwUEBwTY/X2BKUs7rg==",
       "requires": {
         "d3-scale": "^3.3.0",
         "d3-shape": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/carbonplan/blog#readme",
   "dependencies": {
-    "@carbonplan/charts": "^3.0.0",
+    "@carbonplan/charts": "^3.1.1",
     "@carbonplan/colormaps": "^4.0.0",
     "@carbonplan/components": "^12.5.0",
     "@carbonplan/icons": "^2.0.0",


### PR DESCRIPTION
similar to https://github.com/carbonplan/research/pull/287, this fixes scatter plots in safari. (only usage: https://carbonplan.org/blog/open-lidar-biomass)