### PR TITLE
bump maps version for android fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@carbonplan/components": "^12.5.0",
         "@carbonplan/icons": "^2.0.0",
         "@carbonplan/layouts": "^4.0.0",
-        "@carbonplan/maps": "^3.0.0",
+        "@carbonplan/maps": "^3.4.0",
         "@carbonplan/prism": "^2.0.0",
         "@carbonplan/theme": "^8.1.0",
         "@emotion/react": "^11.7.1",
@@ -439,9 +439,9 @@
       }
     },
     "node_modules/@carbonplan/maps": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-3.0.0.tgz",
-      "integrity": "sha512-QZeRZx+uYmeSvUTIutafowQQS3PsHC+hYFx3tQN5HDXfS85KBURCOBQSKRML9EVI3E4xCZUl+JrMN31anuFAIg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-3.4.0.tgz",
+      "integrity": "sha512-5Bwl+R6d/mGVYS9xpUlWNUscE2KQxOnI56a9l+8A5aYQ1t5J97tJ1VQ+3OirhAJIlX/j17sV4rouj5FHmLn/Jw==",
       "dependencies": {
         "@turf/turf": "^6.5.0",
         "d3-array": "^2.12.1",
@@ -449,12 +449,13 @@
         "d3-geo": "^2.0.2",
         "d3-scale": "^2.2.2",
         "d3-selection": "^2.0.0",
+        "glsl-geo-projection": "^1.0.1",
         "mapbox-gl": "^1.13.1",
         "ndarray": "^1.0.19",
         "regl": "^2.1.0",
         "uuid": "^8.3.2",
         "xhr-request": "^1.1.0",
-        "zarr-js": "^2.2.0"
+        "zarr-js": "^3.3.0"
       },
       "peerDependencies": {
         "react": ">=18",
@@ -522,8 +523,9 @@
       "license": "ISC"
     },
     "node_modules/@carbonplan/maps/node_modules/zarr-js": {
-      "version": "2.2.1",
-      "license": "MIT",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-3.3.0.tgz",
+      "integrity": "sha512-zd6owywyeq6rSPyjBGYx9rCK1B+PDiAFKcHFTSYUiTY31CxhqkhZ/UhwB+gAHNIeuiyYCGlGyWuYcgmfa43Zeg==",
       "dependencies": {
         "async": "^2.6.2",
         "cartesian-product": "^2.1.2",
@@ -5013,7 +5015,8 @@
     },
     "node_modules/fflate": {
       "version": "0.7.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -5270,6 +5273,11 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/glsl-geo-projection": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/glsl-geo-projection/-/glsl-geo-projection-1.1.1.tgz",
+      "integrity": "sha512-kUGHDkxReo/GwUINUkWe+e5Up9vWVxx2JaZ3guZwdXMinOD2JFzVSBjz7XYqqOGWS8NoYYqCAVPJN3AuQWsORw=="
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
@@ -9578,9 +9586,9 @@
       }
     },
     "@carbonplan/maps": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-3.0.0.tgz",
-      "integrity": "sha512-QZeRZx+uYmeSvUTIutafowQQS3PsHC+hYFx3tQN5HDXfS85KBURCOBQSKRML9EVI3E4xCZUl+JrMN31anuFAIg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-3.4.0.tgz",
+      "integrity": "sha512-5Bwl+R6d/mGVYS9xpUlWNUscE2KQxOnI56a9l+8A5aYQ1t5J97tJ1VQ+3OirhAJIlX/j17sV4rouj5FHmLn/Jw==",
       "requires": {
         "@turf/turf": "^6.5.0",
         "d3-array": "^2.12.1",
@@ -9588,12 +9596,13 @@
         "d3-geo": "^2.0.2",
         "d3-scale": "^2.2.2",
         "d3-selection": "^2.0.0",
+        "glsl-geo-projection": "^1.0.1",
         "mapbox-gl": "^1.13.1",
         "ndarray": "^1.0.19",
         "regl": "^2.1.0",
         "uuid": "^8.3.2",
         "xhr-request": "^1.1.0",
-        "zarr-js": "^2.2.0"
+        "zarr-js": "^3.3.0"
       },
       "dependencies": {
         "d3-array": {
@@ -9649,7 +9658,9 @@
           "version": "1.0.1"
         },
         "zarr-js": {
-          "version": "2.2.1",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-3.3.0.tgz",
+          "integrity": "sha512-zd6owywyeq6rSPyjBGYx9rCK1B+PDiAFKcHFTSYUiTY31CxhqkhZ/UhwB+gAHNIeuiyYCGlGyWuYcgmfa43Zeg==",
           "requires": {
             "async": "^2.6.2",
             "cartesian-product": "^2.1.2",
@@ -12678,7 +12689,9 @@
       }
     },
     "fflate": {
-      "version": "0.7.4"
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
     },
     "file-entry-cache": {
       "version": "6.0.1",
@@ -12850,6 +12863,11 @@
           "dev": true
         }
       }
+    },
+    "glsl-geo-projection": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/glsl-geo-projection/-/glsl-geo-projection-1.1.1.tgz",
+      "integrity": "sha512-kUGHDkxReo/GwUINUkWe+e5Up9vWVxx2JaZ3guZwdXMinOD2JFzVSBjz7XYqqOGWS8NoYYqCAVPJN3AuQWsORw=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@carbonplan/components": "^12.5.0",
     "@carbonplan/icons": "^2.0.0",
     "@carbonplan/layouts": "^4.0.0",
-    "@carbonplan/maps": "^3.0.0",
+    "@carbonplan/maps": "^3.4.0",
     "@carbonplan/prism": "^2.0.0",
     "@carbonplan/theme": "^8.1.0",
     "@emotion/react": "^11.7.1",


### PR DESCRIPTION
Looks like we've only used full /maps here, no minimaps. It was just used in the announcement post for maps. This update stops the page from crashing on android (tho we still have issues with the fill value not working). 